### PR TITLE
Simplify loading of plugins

### DIFF
--- a/lib/pluginator/autodetect.rb
+++ b/lib/pluginator/autodetect.rb
@@ -64,24 +64,14 @@ module Pluginator
       end
     end
 
+    # @return [Boolean] true if the plugin file was required successfully, 
+    #  false if it failed to require.
     def load_plugin(path)
-      gemspec = Gem::Specification.find_by_path(path)
-      if
-        gemspec
-      then
-        activated =
-        Gem::Specification.find do |spec|
-          spec.name == gemspec.name && spec.activated?
-        end
-        gemspec.activate if !gemspec.activated? && activated.nil?
-        if
-          activated.nil? || activated == gemspec
-        then
-          require path
-          true
-        else
-          nil
-        end
+      begin
+        require path
+        return true
+      rescue ::LoadError
+        return false
       end
     end
 


### PR DESCRIPTION
I ran into the issue that is ultimately the cause of #5. This commit (3754f57de3ad5082b2e85a7d0292be43a92eaef7)  forces the requirement that all plugins be contained within a rubygem. So, pluginator would fail to load any plugins that are in $LOAD_PATH but not in a gem.

I removed the gem activation code as it was duplicating what is already being done by the rubygems' wrapper for 'require'. You can see that there is considerably more logic to the require wrapper than was present in the previous version of 'load_plugin': https://github.com/rubygems/rubygems/blob/master/lib/rubygems/core_ext/kernel_require.rb

This change modifies load_plugin so that it returns true if the path was successfully required, and false if a LoadError occurred. This works for the situation described by #3, which asks that pluginator only load files from activated gems. 

Fixes #5
