### PR TITLE
Adds support to allow dashes in directory names

### DIFF
--- a/lib/pluginator/name_converter.rb
+++ b/lib/pluginator/name_converter.rb
@@ -27,7 +27,7 @@ module Pluginator
       klass = Kernel
       name.to_s.split(%r{/}).each do |part|
         klass = klass.const_get(
-          part.capitalize.gsub(/_(.)/) { |match| match[1].upcase }
+          part.capitalize.gsub(/[_-](.)/) { |match| match[1].upcase }
         )
       end
       klass

--- a/test/pluginator/name_converter_test.rb
+++ b/test/pluginator/name_converter_test.rb
@@ -29,5 +29,13 @@ describe Pluginator::NameConverter do
     it :builds_class do
       Converter.send(:name2class, "Converter").must_equal(Converter)
     end
+
+    it :builds_class_with_dash do
+      Converter.send(:name2class, "puppet-debugger").must_equal(PuppetDebugger)
+    end
+
+    it :builds_class_with_underscore do
+      Converter.send(:name2class, "puppet_debugger").must_equal(PuppetDebugger)
+    end
   end
 end


### PR DESCRIPTION
  * previously the name converter only supported underscores.
    Some gems also use dashes and the pluginator was not able
    to convert these names properly.  This commit fixes that
    by adding the '-' to the list of allowed characters.