### PR TITLE
Fix order of loading files in tests, fixes #14

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,9 @@ then
 
   Coveralls.noisy = true unless ENV["CI"]
 end
+
+# load everything
+require "pluginator"
 # Ensure all files are counted in
 Dir[lib+"/**/*.rb"].each{|file| require file }
 


### PR DESCRIPTION
The following line:
```ruby
Dir[lib+"/**/*.rb"].each{|file| require file }
```
can have system dependent ordering, adding extra:
```ruby
require "pluginator"
```
should ensure proper order of loading classes.